### PR TITLE
Retain full original url in new location

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports = function (opts) {
       return;
     }
 
-    var url = req.url;
+    var url = req.originalUrl;
     var host = req.headers.host || '';
 		if (!/:\d+/.test(host) && 443 !== opts.port) {
 			// we are using standard port 80, but we aren't using standard port 443

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports = function (opts) {
       return;
     }
 
-    var url = req.originalUrl;
+    var url = (req.originalUrl || req.url);
     var host = req.headers.host || '';
 		if (!/:\d+/.test(host) && 443 !== opts.port) {
 			// we are using standard port 80, but we aren't using standard port 443


### PR DESCRIPTION
Use the full original url in building the new location for redirection.

The previous version strips the mount point from the url when reconstructing it for redirection. 

For example, a call to http://servername/users?a=1&b=2, where /users is a router/app mount point, will get redirected to https://servername:port/?a=1&b=2 instead of https://servername:port/users?a=1&b=2.

This change fixes the problem.